### PR TITLE
Add `merge` option to all Agents

### DIFF
--- a/lib/huginn_freme_enrichment_agents/concerns/freme_nif_api_agent_concern.rb
+++ b/lib/huginn_freme_enrichment_agents/concerns/freme_nif_api_agent_concern.rb
@@ -27,6 +27,19 @@ module FremeNifApiAgentConcern
   end
 
   module ClassMethods
+    def common_nif_agent_fields
+      form_configurable :merge, type: :boolean
+      form_configurable :result_key
+    end
+
+    def common_nif_agent_fields_description
+      Utils.unindent <<-MD
+        `merge` set to `true` to retain the received payload and update it with the extracted result
+
+        `result_key` when present the emitted Event data will be nested inside the specified key
+      MD
+    end
+
     def freme_auth_token_description
       "`auth_token` can be set to access private filters, datasets, templates or pipelines (depending on the agent)."
     end
@@ -53,10 +66,14 @@ module FremeNifApiAgentConcern
     response = faraday.run_request(:post, url, mo['body'], headers) do |request|
       request.params.update(params)
     end
-    create_nif_event response, (boolify(mo['merge']) ? options[:event].payload : {})
+
+    create_nif_event!(mo, options[:event], body: response.body, headers: response.headers, status: response.status)
   end
 
-  def create_nif_event(response, original_payload)
-    create_event payload: original_payload.merge(body: response.body, headers: response.headers, status: response.status)
+  def create_nif_event!(mo, event, payload)
+    original_payload = boolify(mo['merge']) ? event.payload : {}
+    payload = {mo['result_key'] => payload} if mo['result_key'].present?
+
+    create_event payload: original_payload.merge(payload)
   end
 end

--- a/lib/huginn_freme_enrichment_agents/concerns/freme_nif_api_agent_concern.rb
+++ b/lib/huginn_freme_enrichment_agents/concerns/freme_nif_api_agent_concern.rb
@@ -38,7 +38,7 @@ module FremeNifApiAgentConcern
     { 'X-Auth-Token' => (mo || interpolated)['auth_token'] }
   end
 
-  def nif_request!(mo, configuration_keys, url)
+  def nif_request!(mo, configuration_keys, url, options = {})
     headers = auth_header(mo).merge({
       'Content-Type' => mo['body_format']
     })
@@ -53,10 +53,10 @@ module FremeNifApiAgentConcern
     response = faraday.run_request(:post, url, mo['body'], headers) do |request|
       request.params.update(params)
     end
-    create_nif_event response
+    create_nif_event response, (boolify(mo['merge']) ? options[:event].payload : {})
   end
 
-  def create_nif_event(response)
-    create_event payload: { body: response.body, headers: response.headers, status: response.status }
+  def create_nif_event(response, original_payload)
+    create_event payload: original_payload.merge(body: response.body, headers: response.headers, status: response.status)
   end
 end

--- a/lib/huginn_freme_enrichment_agents/freme_explore_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_explore_agent.rb
@@ -28,7 +28,7 @@ module Agents
 
       #{filterable_description}
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -48,7 +48,7 @@ module Agents
     form_configurable :endpoint
     form_configurable :endpoint_type, type: :array, values: ['sparql', 'ldf']
     filterable_field
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "base_url needs to be present") if options['base_url'].blank?

--- a/lib/huginn_freme_enrichment_agents/freme_explore_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_explore_agent.rb
@@ -27,6 +27,8 @@ module Agents
       `endpoint_type` the type of the endpoint (required).
 
       #{filterable_description}
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -46,6 +48,7 @@ module Agents
     form_configurable :endpoint
     form_configurable :endpoint_type, type: :array, values: ['sparql', 'ldf']
     filterable_field
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "base_url needs to be present") if options['base_url'].blank?
@@ -59,7 +62,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat', 'resource', 'endpoint', 'endpoint_type'], URI.join(mo['base_url'], 'e-link/explore'))
+        nif_request!(mo, ['outformat', 'resource', 'endpoint', 'endpoint_type'], URI.join(mo['base_url'], 'e-link/explore'), event: event)
       end
     end
   end

--- a/lib/huginn_freme_enrichment_agents/freme_filter_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_filter_agent.rb
@@ -24,6 +24,8 @@ module Agents
       `outformat` requested RDF serialization format of the output
 
       `name` name of filter to execute against, [the official documentation](http://api.freme-project.eu/doc/current/api-doc/full.html#!/Toolbox/get_toolbox_convert_manage) has a list of all available filters.
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -42,6 +44,7 @@ module Agents
     form_configurable :body_format, type: :array, values: ['text/n3', 'text/turtle', 'application/ld+json', 'application/n-triples', 'application/rdf+xml']
     form_configurable :outformat, type: :array, values: ['text/comma-separated-values', 'text/xml', 'application/json', 'application/ld+json', 'text/turtle', 'text/n3', 'application/n-triples', 'application/rdf+xml']
     form_configurable :name, roles: :completable
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -62,7 +65,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat'], URI.join(mo['base_url'], 'toolbox/convert/documents/', mo['name']))
+        nif_request!(mo, ['outformat'], URI.join(mo['base_url'], 'toolbox/convert/documents/', mo['name']), event: event)
       end
     end
   end

--- a/lib/huginn_freme_enrichment_agents/freme_filter_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_filter_agent.rb
@@ -25,7 +25,7 @@ module Agents
 
       `name` name of filter to execute against, [the official documentation](http://api.freme-project.eu/doc/current/api-doc/full.html#!/Toolbox/get_toolbox_convert_manage) has a list of all available filters.
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -44,7 +44,7 @@ module Agents
     form_configurable :body_format, type: :array, values: ['text/n3', 'text/turtle', 'application/ld+json', 'application/n-triples', 'application/rdf+xml']
     form_configurable :outformat, type: :array, values: ['text/comma-separated-values', 'text/xml', 'application/json', 'application/ld+json', 'text/turtle', 'text/n3', 'application/n-triples', 'application/rdf+xml']
     form_configurable :name, roles: :completable
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?

--- a/lib/huginn_freme_enrichment_agents/freme_link_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_link_agent.rb
@@ -30,7 +30,7 @@ module Agents
 
       #{filterable_description}
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -50,7 +50,7 @@ module Agents
     form_configurable :outformat, type: :array, values: ['application/ld+json', 'text/turtle', 'text/n3', 'application/n-triples', 'application/rdf+xml']
     form_configurable :templateid, roles: :completable
     filterable_field
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?

--- a/lib/huginn_freme_enrichment_agents/freme_link_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_link_agent.rb
@@ -29,6 +29,8 @@ module Agents
       `templateid` the ID of the template to be used for enrichment, [the official documentation](http://api.freme-project.eu/doc/current/api-doc/full.html#!/e-Link/getAllTemplates) has a list of all available templates.
 
       #{filterable_description}
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -48,6 +50,7 @@ module Agents
     form_configurable :outformat, type: :array, values: ['application/ld+json', 'text/turtle', 'text/n3', 'application/n-triples', 'application/rdf+xml']
     form_configurable :templateid, roles: :completable
     filterable_field
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -68,7 +71,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat', 'templateid'], URI.join(mo['base_url'], 'e-link/documents'))
+        nif_request!(mo, ['outformat', 'templateid'], URI.join(mo['base_url'], 'e-link/documents'), event: event)
       end
     end
   end

--- a/lib/huginn_freme_enrichment_agents/freme_ner_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_ner_agent.rb
@@ -42,7 +42,7 @@ module Agents
 
       #{filterable_description}
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -71,7 +71,7 @@ module Agents
     form_configurable :linkingMethod, type: :array, values: ['MFS', 'SurfaceFormSimilarity1']
     form_configurable :numLinks
     filterable_field
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?

--- a/lib/huginn_freme_enrichment_agents/freme_ner_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_ner_agent.rb
@@ -41,6 +41,8 @@ module Agents
       `numLinks` Using the numLinks parameter one can specify the maximum number of links to be assigned to an entity. By default only one link is returned. The maximum possible number for this parameter is 5.
 
       #{filterable_description}
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -69,6 +71,7 @@ module Agents
     form_configurable :linkingMethod, type: :array, values: ['MFS', 'SurfaceFormSimilarity1']
     form_configurable :numLinks
     filterable_field
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -90,7 +93,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat', 'prefix', 'language', 'dataset', 'mode', 'domain', 'types', 'numLinks', 'linkingMethod'], URI.join(mo['base_url'], 'e-entity/freme-ner/documents'))
+        nif_request!(mo, ['outformat', 'prefix', 'language', 'dataset', 'mode', 'domain', 'types', 'numLinks', 'linkingMethod'], URI.join(mo['base_url'], 'e-entity/freme-ner/documents'), event: event)
       end
     end
   end

--- a/lib/huginn_freme_enrichment_agents/freme_nif_converter_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_nif_converter_agent.rb
@@ -25,7 +25,7 @@ module Agents
 
         `body` use [Liquid](https://github.com/cantino/huginn/wiki/Formatting-Events-using-Liquid) templating to specify the data to be send to the API.
 
-        #{common_nif_agent_fields_description}
+        #{self.class.common_nif_agent_fields_description}
 
         **When receiving a file pointer:**
 

--- a/lib/huginn_freme_enrichment_agents/freme_nif_converter_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_nif_converter_agent.rb
@@ -25,7 +25,7 @@ module Agents
 
         `body` use [Liquid](https://github.com/cantino/huginn/wiki/Formatting-Events-using-Liquid) templating to specify the data to be send to the API.
 
-        `merge` set to true to retain the received payload and update it with the extracted result
+        #{common_nif_agent_fields_description}
 
         **When receiving a file pointer:**
 
@@ -48,7 +48,7 @@ module Agents
     form_configurable :outformat, type: :array, values: ['text/n3', 'text/turtle', 'application/ld+json', 'application/n-triples', 'application/rdf+xml']
     form_configurable :body_format, type: :array, values: ['text/plain', 'text/xml', 'text/html', 'text/n3', 'text/turtle', 'application/ld+json', 'application/n-triples', 'application/rdf+xml', 'application/x-xliff+xml', 'application/x-openoffice']
     form_configurable :body, type: :text, ace: true
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -68,7 +68,7 @@ module Agents
 
           response = faraday.post(URI.join(mo['base_url'], 'toolbox/nif-converter'), mo.slice('inputFile', 'informat','outformat'), headers)
 
-          create_nif_event(response, (boolify(mo['merge']) ? event.payload : {}))
+          create_nif_event!(mo, event, body: response.body, headers: response.headers, status: response.status)
         else
           nif_request!(mo, ['outformat'], URI.join(mo['base_url'], 'toolbox/nif-converter'), event: event)
         end

--- a/lib/huginn_freme_enrichment_agents/freme_nif_converter_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_nif_converter_agent.rb
@@ -25,6 +25,8 @@ module Agents
 
         `body` use [Liquid](https://github.com/cantino/huginn/wiki/Formatting-Events-using-Liquid) templating to specify the data to be send to the API.
 
+        `merge` set to true to retain the received payload and update it with the extracted result
+
         **When receiving a file pointer:**
 
         `body` and `body_format` will be ignored and the received file will be converted using Apache Tika.
@@ -46,6 +48,7 @@ module Agents
     form_configurable :outformat, type: :array, values: ['text/n3', 'text/turtle', 'application/ld+json', 'application/n-triples', 'application/rdf+xml']
     form_configurable :body_format, type: :array, values: ['text/plain', 'text/xml', 'text/html', 'text/n3', 'text/turtle', 'application/ld+json', 'application/n-triples', 'application/rdf+xml', 'application/x-xliff+xml', 'application/x-openoffice']
     form_configurable :body, type: :text, ace: true
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -65,9 +68,9 @@ module Agents
 
           response = faraday.post(URI.join(mo['base_url'], 'toolbox/nif-converter'), mo.slice('inputFile', 'informat','outformat'), headers)
 
-          create_nif_event(response)
+          create_nif_event(response, (boolify(mo['merge']) ? event.payload : {}))
         else
-          nif_request!(mo, ['outformat'], URI.join(mo['base_url'], 'toolbox/nif-converter'))
+          nif_request!(mo, ['outformat'], URI.join(mo['base_url'], 'toolbox/nif-converter'), event: event)
         end
       end
     end

--- a/lib/huginn_freme_enrichment_agents/freme_pipeline_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_pipeline_agent.rb
@@ -26,6 +26,8 @@ module Agents
       `stats` If true, adds timing statistics to the response: total duration of the pipeline and duration of each service called in the pipeline (in milliseconds).
 
       `useI18n` If `false`, enforces to not use [e-Internalization](https://freme-project.github.io//knowledge-base/freme-for-api-users/eInternationalisation.html), even if Content-Type header is one of the possible e-Internalization formats. For any othe value, e-Internalization will be used, if possible.
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -44,6 +46,7 @@ module Agents
     form_configurable :body, type: :text, ace: true
     form_configurable :stats, type: :boolean
     form_configurable :useI18n, type: :boolean
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -63,10 +66,10 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
         if mo['template_id'].present?
-          nif_request!(mo, ['stats', 'useI18n'], URI.join(mo['base_url'], "pipelining/chain/#{mo['template_id']}"))
+          nif_request!(mo, ['stats', 'useI18n'], URI.join(mo['base_url'], "pipelining/chain/#{mo['template_id']}"), event: event)
         else
           mo['body_format'] = 'application/json'
-          nif_request!(mo, ['stats', 'useI18n'], URI.join(mo['base_url'], 'pipelining/chain'))
+          nif_request!(mo, ['stats', 'useI18n'], URI.join(mo['base_url'], 'pipelining/chain'), event: event)
         end
       end
     end

--- a/lib/huginn_freme_enrichment_agents/freme_pipeline_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_pipeline_agent.rb
@@ -27,7 +27,7 @@ module Agents
 
       `useI18n` If `false`, enforces to not use [e-Internalization](https://freme-project.github.io//knowledge-base/freme-for-api-users/eInternationalisation.html), even if Content-Type header is one of the possible e-Internalization formats. For any othe value, e-Internalization will be used, if possible.
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -46,7 +46,7 @@ module Agents
     form_configurable :body, type: :text, ace: true
     form_configurable :stats, type: :boolean
     form_configurable :useI18n, type: :boolean
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?

--- a/lib/huginn_freme_enrichment_agents/freme_spotlight_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_spotlight_agent.rb
@@ -34,7 +34,7 @@ module Agents
 
       #{filterable_description}
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -60,7 +60,7 @@ module Agents
     form_configurable :numLinks
     form_configurable :confidence
     filterable_field
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?

--- a/lib/huginn_freme_enrichment_agents/freme_spotlight_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_spotlight_agent.rb
@@ -33,6 +33,8 @@ module Agents
       `confidence` Setting a high confidence threshold instructs DBpedia Spotlight to avoid incorrect annotations as much as possible at the risk of losing some correct ones. A confidence value of 0.7 will eliminate 70% of incorrectly disambiguated test cases. The range of the confidence parameter is between 0 and 1. Default is 0.3.
 
       #{filterable_description}
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -58,6 +60,7 @@ module Agents
     form_configurable :numLinks
     form_configurable :confidence
     filterable_field
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -71,7 +74,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat', 'prefix', 'language', 'numLinks','confidence'], URI.join(mo['base_url'], 'e-entity/dbpedia-spotlight/documents'))
+        nif_request!(mo, ['outformat', 'prefix', 'language', 'numLinks','confidence'], URI.join(mo['base_url'], 'e-entity/dbpedia-spotlight/documents'), event: event)
       end
     end
   end

--- a/lib/huginn_freme_enrichment_agents/freme_terminology_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_terminology_agent.rb
@@ -40,7 +40,7 @@ module Agents
 
       #{filterable_description}
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -72,7 +72,7 @@ module Agents
     form_configurable :domain
     form_configurable :key
     filterable_field
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?

--- a/lib/huginn_freme_enrichment_agents/freme_terminology_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_terminology_agent.rb
@@ -39,6 +39,8 @@ module Agents
       `key` A private key to access private and not publicly available translation systems. Key can be created by contacting [Tilde](http://www.tilde.com/mt/contacts) team. Optional, if omitted then translates with public systems
 
       #{filterable_description}
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -70,6 +72,7 @@ module Agents
     form_configurable :domain
     form_configurable :key
     filterable_field
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -82,7 +85,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat', 'prefix', 'source_lang', 'target_lang','collection', 'mode', 'domain', 'key',], URI.join(mo['base_url'], 'e-terminology/tilde'))
+        nif_request!(mo, ['outformat', 'prefix', 'source_lang', 'target_lang','collection', 'mode', 'domain', 'key',], URI.join(mo['base_url'], 'e-terminology/tilde'), event: event)
       end
     end
   end

--- a/lib/huginn_freme_enrichment_agents/freme_translation_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_translation_agent.rb
@@ -36,7 +36,7 @@ module Agents
 
       #{filterable_description}
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -64,7 +64,7 @@ module Agents
     form_configurable :domain
     form_configurable :system
     filterable_field
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?

--- a/lib/huginn_freme_enrichment_agents/freme_translation_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_translation_agent.rb
@@ -35,6 +35,8 @@ module Agents
       `system` select translation system by ID [an alternative to source, target language and domain selection]. ID of public translation system can be retrieved at [https://services.tilde.com/translationsystems](https://services.tilde.com/translationsystems) or private system ID can be found at portal [http://tilde.com/mt](http://tilde.com/mt) with authentication [optional, if omitted then source and target languages and also domain parameters are used]
 
       #{filterable_description}
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -62,6 +64,7 @@ module Agents
     form_configurable :domain
     form_configurable :system
     filterable_field
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -76,7 +79,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat', 'prefix', 'source_lang', 'target_lang', 'key', 'domain', 'system'], URI.join(mo['base_url'], 'e-terminology/tilde'))
+        nif_request!(mo, ['outformat', 'prefix', 'source_lang', 'target_lang', 'key', 'domain', 'system'], URI.join(mo['base_url'], 'e-terminology/tilde'), event: event)
       end
     end
   end

--- a/lib/huginn_freme_enrichment_agents/freme_xslt_converter_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_xslt_converter_agent.rb
@@ -24,6 +24,8 @@ module Agents
       `outformat` requested format of the output
 
       `name` name of filter to execute against, [the official documentation](https://freme-project.github.io/api-doc/full.html#!/Toolbox%2FXSLT-Converter/get_toolbox_xslt_converter_manage) has a list of all available filters.
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -42,6 +44,7 @@ module Agents
     form_configurable :outformat, type: :array, values: ['text/xml', 'text/html']
     form_configurable :name, roles: :completable
     form_configurable :body, type: :text
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?
@@ -62,7 +65,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat'], URI.join(mo['base_url'], 'toolbox/xslt-converter/documents/', mo['name']))
+        nif_request!(mo, ['outformat'], URI.join(mo['base_url'], 'toolbox/xslt-converter/documents/', mo['name']), event: event)
       end
     end
   end

--- a/lib/huginn_freme_enrichment_agents/freme_xslt_converter_agent.rb
+++ b/lib/huginn_freme_enrichment_agents/freme_xslt_converter_agent.rb
@@ -25,7 +25,7 @@ module Agents
 
       `name` name of filter to execute against, [the official documentation](https://freme-project.github.io/api-doc/full.html#!/Toolbox%2FXSLT-Converter/get_toolbox_xslt_converter_manage) has a list of all available filters.
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -44,7 +44,7 @@ module Agents
     form_configurable :outformat, type: :array, values: ['text/xml', 'text/html']
     form_configurable :name, roles: :completable
     form_configurable :body, type: :text
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "body needs to be present") if options['body'].blank?

--- a/spec/support/shared_examples/freme_nif_api_agent_concern.rb
+++ b/spec/support/shared_examples/freme_nif_api_agent_concern.rb
@@ -22,4 +22,26 @@ shared_examples_for FremeNifApiAgentConcern do
     mock(@checker).receive([event])
     @checker.check
   end
+
+  context '#merge' do
+    let(:event) { Event.new(payload: {some: 'data'}) }
+
+    before do
+      stub_request(:any, //).
+         to_return(:status => 200, :body => '{"some": "json"}', :headers => {})
+    end
+
+    it 'does not merge the received event into the result per default' do
+      expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+      event = Event.last
+      expect(event.payload[:some]).to be_nil
+    end
+
+    it 'merges the results with the received event when merge is set to true' do
+      @checker.options['merge'] = "true"
+      expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+      event = Event.last
+      expect(event.payload[:some]).to eq('data')
+    end
+  end
 end

--- a/spec/support/shared_examples/freme_nif_api_agent_concern.rb
+++ b/spec/support/shared_examples/freme_nif_api_agent_concern.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 shared_examples_for FremeNifApiAgentConcern do
+  it 'renders the description wihtout errors' do
+    expect { @checker.description }.not_to raise_error
+  end
+
   it "event description does not throw an exception" do
     expect(@checker.event_description).to include('body')
   end

--- a/spec/support/shared_examples/freme_nif_api_agent_concern.rb
+++ b/spec/support/shared_examples/freme_nif_api_agent_concern.rb
@@ -44,4 +44,27 @@ shared_examples_for FremeNifApiAgentConcern do
       expect(event.payload[:some]).to eq('data')
     end
   end
+
+  context 'result_key' do
+    let(:event) { Event.new }
+
+    before do
+      stub_request(:any, //).
+         to_return(:status => 200, :body => '{"some": "json"}', :headers => {})
+    end
+
+    it 'emits the data in the payload root when not result_key is set' do
+      expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+      event = Event.last
+      expect(event.payload[:body]).not_to be_nil
+    end
+
+    it 'nests the data inside result_key when it is set' do
+      @checker.options['result_key'] = 'data'
+      expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+      event = Event.last
+      expect(event.payload[:body]).to be_nil
+      expect(event.payload[:data]).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
When `merge` is set to true the received event will be merged into the emitted data
